### PR TITLE
Fixed using external and internal user id in a rental

### DIFF
--- a/car-database-api/Controllers/Customer/RentalsController.cs
+++ b/car-database-api/Controllers/Customer/RentalsController.cs
@@ -102,7 +102,7 @@ public class RentalsController(CarRentalDbContext context, IMapper mapper) : Con
         var rental = new Rental
         {
             carId = offer.carId,
-            userId = request.CustomerId,
+            userId = user.id,
             startDate = request.PlannedStartDate,
             endDate = request.PlannedEndDate,
             totalPrice = (offer.dailyRate + offer.insuranceRate) * 
@@ -125,7 +125,7 @@ public class RentalsController(CarRentalDbContext context, IMapper mapper) : Con
         {
             Id = rental.id,
             CarId = rental.carId,
-            UserId = rental.userId,
+            UserId = user.externalId,
             StartDate = rental.startDate,
             EndDate = rental.endDate,
             TotalPrice = rental.totalPrice,


### PR DESCRIPTION
There was a bug that caused the FK constraint in the database to crash creating rental process